### PR TITLE
docs(branding): update library name in documentation

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -7,7 +7,8 @@ env:
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "docs/**"
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the documentation for the TypeScript Core Utilities library.
+Welcome to the documentation for the ClaDI - TypeScript Core Utilities library.
 
 This library provides a set of foundational classes and interfaces for building robust applications, focusing on dependency injection, registry patterns, factories, and standardized logging and error handling.
 
@@ -10,4 +10,4 @@ Explore the sections to learn how to leverage these core components:
 - **Core Concepts**: Understand the fundamental patterns like Container, Registry, Factory, and Error handling.
 - **Services**: Learn about available services like the Console Logger.
 - **Utilities**: Discover helper functions for creating core components.
-- **API Reference**: Detailed reference for all public interfaces, classes, and enums. 
+- **API Reference**: Detailed reference for all public interfaces, classes, and enums.


### PR DESCRIPTION
Updated introduction to include 'ClaDI' in the library name for consistent branding. Also formatted GitHub workflow file branches configuration for better readability.