### PR TITLE
fix(ci): add kebab case repo name handling in docs mirroring workflow

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -28,6 +28,8 @@ jobs:
         id: vars
         run: |
           echo "REPO_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
+          KEBAB_CASE_REPO_NAME=$(echo "$REPO_NAME" | sed -E 's/([A-Z])/-\L\1/g' | sed -E 's/[_\s]+/-/g' | sed -E 's/^-//' | tr '[:upper:]' '[:lower:]')
+          echo "KEBAB_CASE_REPO_NAME=KEBAB_CASE_REPO_NAME" >> $GITHUB_OUTPUT
           echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Checkout destination repository
@@ -44,7 +46,7 @@ jobs:
           cd destination
           git checkout -b feature/${{ steps.vars.outputs.REPO_NAME }}_${{ steps.vars.outputs.DATE }}
 
-          TARGET_DIR="src/app/${{ steps.vars.outputs.KEBAB_CASE }}"
+          TARGET_DIR="src/app/${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}"
           mkdir -p "$TARGET_DIR"
 
           cp -r ../source/docs/* "$TARGET_DIR/"
@@ -53,4 +55,4 @@ jobs:
           git config user.email "<>"
 
           git add .
-          git diff --quiet && git diff --staged --quiet || (git commit -m "docs(documentation): sync docs from ${{ steps.vars.outputs.REPO_NAME }} repo on ${{ steps.vars.outputs.DATE }}" && git push --set-upstream origin feature/${{ steps.vars.outputs.REPO_NAME }}_${{ steps.vars.outputs.DATE }})
+          git diff --quiet && git diff --staged --quiet || (git commit -m "docs(documentation): sync docs from ${{ steps.vars.outputs.REPO_NAME }} repo on ${{ steps.vars.outputs.DATE }}" && git push --set-upstream origin feature/docs-${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}_${{ steps.vars.outputs.DATE }})

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ This library provides a set of foundational classes and interfaces for building 
 
 Explore the sections to learn how to leverage these core components:
 
-- **Getting Started**: Quick guide to installation and basic setup.
+- **Getting Started**: Quick guide to ClaDI installation and basic setup.
 - **Core Concepts**: Understand the fundamental patterns like Container, Registry, Factory, and Error handling.
 - **Services**: Learn about available services like the Console Logger.
 - **Utilities**: Discover helper functions for creating core components.


### PR DESCRIPTION
Fixed the doc mirroring GitHub workflow by properly creating and using a kebab case version of the repository name. This ensures the correct target directory is used when syncing documentation. Also updated the branch naming convention to include 'docs-' prefix for clarity. Minor update to the ClaDI reference in docs index.