### PR TITLE
fix(ci): correct variable substitution in docs workflow and simplify …

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           echo "REPO_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
           KEBAB_CASE_REPO_NAME=$(echo "$REPO_NAME" | sed -E 's/([A-Z])/-\L\1/g' | sed -E 's/[_\s]+/-/g' | sed -E 's/^-//' | tr '[:upper:]' '[:lower:]')
-          echo "KEBAB_CASE_REPO_NAME=KEBAB_CASE_REPO_NAME" >> $GITHUB_OUTPUT
+          echo "KEBAB_CASE_REPO_NAME=$KEBAB_CASE_REPO_NAME" >> $GITHUB_OUTPUT
           echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Checkout destination repository

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ This library provides a set of foundational classes and interfaces for building 
 
 Explore the sections to learn how to leverage these core components:
 
-- **Getting Started**: Quick guide to ClaDI installation and basic setup.
+- **Getting Started**: Quick guide to installation and basic setup.
 - **Core Concepts**: Understand the fundamental patterns like Container, Registry, Factory, and Error handling.
 - **Services**: Learn about available services like the Console Logger.
 - **Utilities**: Discover helper functions for creating core components.


### PR DESCRIPTION
…index text

Fixed the GitHub workflow that was incorrectly echoing the literal string 'KEBAB_CASE_REPO_NAME' instead of the actual variable value. This was causing incorrect repository naming in the docs mirroring process.

Also removed specific product name from the Getting Started section in index.mdx to make the documentation more generic.