### PR TITLE
fix(workflows): improve docs mirroring workflow with better kebab cas…

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -27,9 +27,15 @@ jobs:
       - name: Get repo name and date
         id: vars
         run: |
-          echo "REPO_NAME=$(basename $GITHUB_REPOSITORY)" >> $GITHUB_OUTPUT
+          REPO_NAME=$(basename $GITHUB_REPOSITORY)
+          echo "REPO_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
+
           KEBAB_CASE_REPO_NAME=$(echo "$REPO_NAME" | sed -E 's/([A-Z])/-\L\1/g' | sed -E 's/[_\s]+/-/g' | sed -E 's/^-//' | tr '[:upper:]' '[:lower:]')
           echo "KEBAB_CASE_REPO_NAME=$KEBAB_CASE_REPO_NAME" >> $GITHUB_OUTPUT
+
+          echo "Debug - REPO_NAME: $REPO_NAME"
+          echo "Debug - KEBAB_CASE_REPO_NAME: $KEBAB_CASE_REPO_NAME"
+
           echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
 
       - name: Checkout destination repository
@@ -43,8 +49,10 @@ jobs:
 
       - name: Create and push to feature branch
         run: |
+          BRANCH_NAME="feature/docs-${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}_${{ steps.vars.outputs.DATE }}"
+
           cd destination
-          git checkout -b feature/${{ steps.vars.outputs.REPO_NAME }}_${{ steps.vars.outputs.DATE }}
+          git checkout -b "$BRANCH_NAME"
 
           TARGET_DIR="src/app/${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}"
           mkdir -p "$TARGET_DIR"
@@ -55,4 +63,4 @@ jobs:
           git config user.email "<>"
 
           git add .
-          git diff --quiet && git diff --staged --quiet || (git commit -m "docs(documentation): sync docs from ${{ steps.vars.outputs.REPO_NAME }} repo on ${{ steps.vars.outputs.DATE }}" && git push --set-upstream origin feature/docs-${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}_${{ steps.vars.outputs.DATE }})
+          git diff --quiet && git diff --staged --quiet || (git commit -m "docs(documentation): sync docs from ${{ steps.vars.outputs.REPO_NAME }} repo on ${{ steps.vars.outputs.DATE }}" && git push --set-upstream origin "$BRANCH_NAME")

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ This library provides a set of foundational classes and interfaces for building 
 
 Explore the sections to learn how to leverage these core components:
 
-- **Getting Started**: Quick guide to installation and basic setup.
+- **Getting Started**: Quick guide to ClaDi installation and basic setup.
 - **Core Concepts**: Understand the fundamental patterns like Container, Registry, Factory, and Error handling.
 - **Services**: Learn about available services like the Console Logger.
 - **Utilities**: Discover helper functions for creating core components.


### PR DESCRIPTION
…e naming

Add debug logs to troubleshoot repository name conversion to kebab case. Store branch name in a variable before using it to ensure consistency. Use quotes around variables for better shell script practices.

Also updated the docs index page with a minor clarification about ClaDi installation.