### PR TITLE
fix(ci): replace underscore with hyphen in branch name generation

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd destination
 
-          BASE_BRANCH_NAME="feature/docs-${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}_${{ steps.vars.outputs.DATE }}"
+          BASE_BRANCH_NAME="feature/docs-${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}-${{ steps.vars.outputs.DATE }}"
 
           REMOTE_BRANCHES=$(git ls-remote --heads origin "$BASE_BRANCH_NAME")
 


### PR DESCRIPTION
Modified the branch naming format in mirror-docs-to-docviewer workflow to use hyphens instead of underscores between components. This ensures consistent branch naming conventions and improves compatibility with systems that may have issues with underscores.