### PR TITLE
docs(index): clarify that getting started section is for cladi

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -6,7 +6,7 @@ This library provides a set of foundational classes and interfaces for building 
 
 Explore the sections to learn how to leverage these core components:
 
-- **Getting Started**: Quick guide to installation and basic setup.
+- **Getting Started**: Quick guide to ClaDI installation and basic setup.
 - **Core Concepts**: Understand the fundamental patterns like Container, Registry, Factory, and Error handling.
 - **Services**: Learn about available services like the Console Logger.
 - **Utilities**: Discover helper functions for creating core components.


### PR DESCRIPTION
Updated the Getting Started bullet point in the main documentation index to specifically mention ClaDI, making it clearer to users that the section relates to the library installation and setup.