### PR TITLE
docs(testing): add cladi-testing toolkit documentation and readme sec…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - [Project Structure](#-project-structure)
 - [Prerequisites](#-prerequisites)
 - [Installation](#-installation)
+- [Testing Toolkit](#-testing-toolkit)
 - [Usage](#-usage)
 - [API Quick Reference](#-api-quick-reference)
 - [Production Bootstrap](#-production-bootstrap)
@@ -81,6 +82,7 @@ ClaDI ships with **5 provider strategies** (`useValue`, `useClass`, `useFactory`
 - ✨ **Module System** — `createModule()` and `composeModules()` enable declarative, bounded-context module composition with explicit export contracts
 - ✨ **Decorator Support** — Optional `@Injectable()`, `@Inject()`, `@Module()`, `@OnInit()`, `@AfterResolve()`, and `@OnDispose()` without requiring `reflect-metadata`
 - ✨ **Decorator Composition Helpers** — `autowire()`, `createModuleFromDecorator()`, and `composeDecoratedModules()` keep decorator workflows explicit but concise
+- ✨ **Companion Testing Toolkit** — `@elsikora/cladi-testing` adds test container helpers (`createTestingContainer`, `mockProvider`, `overrideProvider`) for app-level integration and unit tests
 - ✨ **Runtime Diagnostics** — `explain(token)`, `snapshot()`, and `exportGraph()` provide operational visibility into provider lookup and dependency edges
 - ✨ **Deterministic Disposal** — `dispose()` waits for in-flight async resolutions, runs disposers in reverse order, and supports `Symbol.dispose` / `Symbol.asyncDispose`
 - ✨ **Resolve Interceptors** — Hook into every resolution with `onStart`, `onSuccess`, and `onError` callbacks for logging, metrics, or tracing
@@ -299,6 +301,40 @@ npm run test:all
 
 # Run linting
 npm run lint:all
+```
+
+## 🧪 Testing Toolkit
+
+For application tests, use the companion package `@elsikora/cladi-testing` with ClaDI `>=2.1.0`:
+
+```bash
+npm install -D @elsikora/cladi @elsikora/cladi-testing
+```
+
+```typescript
+import { createModule, createToken } from "@elsikora/cladi";
+import { createTestingContainer, mockProvider, overrideProvider, resetTestingContainer } from "@elsikora/cladi-testing";
+
+const UserRepoToken = createToken<{ findNameById(id: string): string | undefined }>("UserRepo");
+const UserServiceToken = createToken<{ readName(id: string): string }>("UserService");
+
+const appModule = createModule({
+	exports: [UserServiceToken],
+	providers: [
+		mockProvider(UserRepoToken, { findNameById: () => "Alice" }),
+		{
+			deps: [UserRepoToken],
+			provide: UserServiceToken,
+			useFactory: (repository) => ({
+				readName: (id: string): string => repository.findNameById(id) ?? "unknown",
+			}),
+		},
+	],
+});
+
+const container = createTestingContainer({ modules: [appModule], shouldValidateOnCreate: true });
+await overrideProvider(container, mockProvider(UserRepoToken, { findNameById: () => "Bob" }));
+await resetTestingContainer(container);
 ```
 
 ## 💡 Usage

--- a/docs/getting-started/page.mdx
+++ b/docs/getting-started/page.mdx
@@ -13,6 +13,12 @@ This guide sets up a minimal composition root with typed tokens, scoped resoluti
 	<Tabs.Tab>```bash copy bun add @elsikora/cladi ```</Tabs.Tab>
 </Tabs>
 
+For test suites in ClaDI-based apps, add the companion testing package:
+
+```bash copy
+npm install -D @elsikora/cladi-testing
+```
+
 ## First Composition Root
 
 ```ts filename="src/bootstrap.ts" copy
@@ -73,4 +79,5 @@ try {
 - [Decorator Modules](/docs/cladi/core-concepts/decorator-modules)
 - [Composition Root Checklist](/docs/cladi/getting-started/composition-root-checklist)
 - [Creation Helpers](/docs/cladi/utilities/creation-helpers)
+- [Testing with ClaDI Testing](/docs/cladi/utilities/testing-with-cladi-testing)
 - [Clean Architecture Playbook](/docs/cladi/core-concepts/clean-architecture-playbook)

--- a/docs/page.mdx
+++ b/docs/page.mdx
@@ -15,11 +15,13 @@ ClaDI is a zero-dependency TypeScript toolkit for modular dependency injection a
 - Runtime diagnostics (`validate`, `explain`, `snapshot`, `exportGraph`)
 - Startup hardening (`bootstrap`, `lock`, `isLocked`)
 - Optional ergonomics for modules and decorators (`autowire`, `composeDecoratedModules`)
+- Dedicated testing helpers via companion package (`@elsikora/cladi-testing`)
 
 ## Documentation Map
 
 - **Getting Started** - install, bootstrap, and first composition root
 - **Core Concepts** - container behavior, provider patterns, and architecture guidance
 - **Utilities** - helper APIs for container/token/provider/logging setup
+- **Testing Utilities** - practical patterns for `createTestingContainer`, `mockProvider`, and `overrideProvider`
 - **Services** - logger contracts and implementation
 - **API Reference** - exported enums and interfaces

--- a/docs/utilities/_meta.js
+++ b/docs/utilities/_meta.js
@@ -1,4 +1,5 @@
 export default {
 	"creation-helpers": "Creation Helpers",
 	"metadata-introspection": "Metadata Introspection",
+	"testing-with-cladi-testing": "Testing with ClaDI Testing",
 };

--- a/docs/utilities/creation-helpers/page.mdx
+++ b/docs/utilities/creation-helpers/page.mdx
@@ -56,3 +56,9 @@ When using decorators, these helpers bridge class metadata to provider/module co
 - `autowire(Class)` - shorthand that reads `token` and lifecycle/dependency metadata from `@Injectable`.
 - `createModuleFromDecorator(ModuleClass)` - converts `@Module` classes into plain `IDIModule` definitions.
 - `composeDecoratedModules(container, modules)` - composes mixed decorated module classes and plain modules directly.
+
+## Testing Helper Package
+
+For app-level test composition, use the companion package [`@elsikora/cladi-testing`](https://www.npmjs.com/package/@elsikora/cladi-testing), documented here:
+
+- [Testing with ClaDI Testing](/docs/cladi/utilities/testing-with-cladi-testing)

--- a/docs/utilities/page.mdx
+++ b/docs/utilities/page.mdx
@@ -8,3 +8,4 @@ Utility helpers simplify composition-root setup.
 
 - **[Creation Helpers](/docs/cladi/utilities/creation-helpers)** — typed tokens, container creation, lazy providers, and logger creation.
 - **[Metadata Introspection](/docs/cladi/utilities/metadata-introspection)** — inspect `@Injectable` and `@Module` metadata at runtime.
+- **[Testing with ClaDI Testing](/docs/cladi/utilities/testing-with-cladi-testing)** — create dedicated testing containers, mock/override providers, and reset state safely between tests.

--- a/docs/utilities/testing-with-cladi-testing/page.mdx
+++ b/docs/utilities/testing-with-cladi-testing/page.mdx
@@ -1,0 +1,78 @@
+# Testing with ClaDI Testing
+
+`@elsikora/cladi-testing` is the companion package for test setup in ClaDI applications.
+
+It keeps tests explicit and composition-root friendly while reducing repetitive wiring.
+
+## Installation
+
+```bash copy
+npm install -D @elsikora/cladi @elsikora/cladi-testing
+```
+
+Compatibility:
+
+- `@elsikora/cladi-testing` requires `@elsikora/cladi >= 2.1.0`
+
+## Core Helpers
+
+- `createTestingContainer(options?)` - create a container preconfigured for test scenarios.
+- `mockProvider(token, valueOrFactory, options?)` - build value or factory-based test doubles.
+- `overrideProvider(container, provider)` - replace a registered provider in current scope.
+- `resetTestingContainer(container)` - dispose and clean all resources between tests.
+- `composeTestingModules(container, modules)` - compose mixed plain and decorator-based modules.
+
+## Minimal Example
+
+```ts filename="test/user-service.test.ts" copy
+import { createModule, createToken } from "@elsikora/cladi";
+import { createTestingContainer, mockProvider, overrideProvider, resetTestingContainer } from "@elsikora/cladi-testing";
+import { afterEach, describe, expect, it } from "vitest";
+
+interface IUserRepository {
+	findNameById(id: string): string | undefined;
+}
+
+interface IUserService {
+	readName(id: string): string;
+}
+
+const UserRepositoryToken = createToken<IUserRepository>("UserRepository");
+const UserServiceToken = createToken<IUserService>("UserService");
+
+const appModule = createModule({
+	exports: [UserServiceToken],
+	providers: [
+		mockProvider(UserRepositoryToken, { findNameById: () => "Alice" }),
+		{
+			deps: [UserRepositoryToken],
+			provide: UserServiceToken,
+			useFactory: (repo): IUserService => ({
+				readName: (id: string): string => repo.findNameById(id) ?? "unknown",
+			}),
+		},
+	],
+});
+
+const container = createTestingContainer({
+	modules: [appModule],
+	shouldValidateOnCreate: true,
+});
+
+afterEach(async () => {
+	await resetTestingContainer(container);
+});
+
+describe("UserService", () => {
+	it("reads name from default mock", () => {
+		const service = container.resolve(UserServiceToken);
+		expect(service.readName("u1")).toBe("Alice");
+	});
+
+	it("supports provider override per scenario", async () => {
+		await overrideProvider(container, mockProvider(UserRepositoryToken, { findNameById: () => "Bob" }));
+		const service = container.resolve(UserServiceToken);
+		expect(service.readName("u2")).toBe("Bob");
+	});
+});
+```


### PR DESCRIPTION
…tion

Add comprehensive documentation for the companion @elsikora/cladi-testing package. Include testing toolkit section in README with usage examples. Add new utilities documentation pages for testing helpers. Document createTestingContainer, mockProvider, and overrideProvider APIs.