### PR TITLE
docs(api-reference): update tsdoc components to use generatedefinitio…

### DIFF
--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -1,4 +1,4 @@
-import { unstable_TSDoc as TSDoc } from "nextra/tsdoc";
+import { generateDefinition, TSDoc } from "nextra/tsdoc";
 
 # Interfaces
 
@@ -9,27 +9,33 @@ This page groups the primary exported contracts used for container setup, provid
 ### `IDIContainer`, `IDIScope`, `IDIResolver`
 
 <TSDoc
-	code={`import type { IDIContainer, IDIScope, IDIResolver } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { IDIContainer, IDIScope, IDIResolver } from "@elsikora/cladi";
 export interface ContainerContracts {
   container: IDIContainer;
   scope: IDIScope;
   resolver: IDIResolver;
 }
-export default ContainerContracts`}
+export default ContainerContracts`,
+	})}
 />
 
 ### `IDIContainerOptions`
 
 <TSDoc
-	code={`import type { IDIContainerOptions } from "@elsikora/cladi";
-export default IDIContainerOptions`}
+	definition={generateDefinition({
+		code: `import type { IDIContainerOptions } from "@elsikora/cladi";
+export default IDIContainerOptions`,
+	})}
 />
 
 ### `IResolveInterceptor`
 
 <TSDoc
-	code={`import type { IResolveInterceptor } from "@elsikora/cladi";
-export default IResolveInterceptor`}
+	definition={generateDefinition({
+		code: `import type { IResolveInterceptor } from "@elsikora/cladi";
+export default IResolveInterceptor`,
+	})}
 />
 
 ## Provider Contracts
@@ -37,19 +43,23 @@ export default IResolveInterceptor`}
 ### `Provider` and `Token<T>`
 
 <TSDoc
-	code={`import type { Provider, Token } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { Provider, Token } from "@elsikora/cladi";
 export interface ProviderReference {
   provider: Provider;
   token: Token<unknown>;
 }
-export default ProviderReference`}
+export default ProviderReference`,
+	})}
 />
 
 ### `ILazyProvider`
 
 <TSDoc
-	code={`import type { ILazyProvider } from "@elsikora/cladi";
-export default ILazyProvider`}
+	definition={generateDefinition({
+		code: `import type { ILazyProvider } from "@elsikora/cladi";
+export default ILazyProvider`,
+	})}
 />
 
 ## Logging and Errors
@@ -57,34 +67,40 @@ export default ILazyProvider`}
 ### `ILogger` and `ILoggerMethodOptions`
 
 <TSDoc
-	code={`import type { ILogger, ILoggerMethodOptions } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { ILogger, ILoggerMethodOptions } from "@elsikora/cladi";
 export interface LoggerContracts {
   logger: ILogger;
   options: ILoggerMethodOptions;
 }
-export default LoggerContracts`}
+export default LoggerContracts`,
+	})}
 />
 
 ### `IError` and `IBaseErrorOptions`
 
 <TSDoc
-	code={`import type { IError, IBaseErrorOptions } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { IError, IBaseErrorOptions } from "@elsikora/cladi";
 export interface ErrorContracts {
   error: IError;
   options: IBaseErrorOptions;
 }
-export default ErrorContracts`}
+export default ErrorContracts`,
+	})}
 />
 
 ### `IConsoleLoggerOptions` and `ICoreFactoryOptions`
 
 <TSDoc
-	code={`import type { IConsoleLoggerOptions, ICoreFactoryOptions } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { IConsoleLoggerOptions, ICoreFactoryOptions } from "@elsikora/cladi";
 export interface InfraFactoryContracts {
   logger: IConsoleLoggerOptions;
   factory: ICoreFactoryOptions;
 }
-export default InfraFactoryContracts`}
+export default InfraFactoryContracts`,
+	})}
 />
 
 ## Graph and Decorator Contracts
@@ -92,22 +108,26 @@ export default InfraFactoryContracts`}
 ### `IDependencyGraph`, `IDependencyGraphNode`, `IDependencyGraphEdge`
 
 <TSDoc
-	code={`import type { IDependencyGraph, IDependencyGraphNode, IDependencyGraphEdge } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { IDependencyGraph, IDependencyGraphNode, IDependencyGraphEdge } from "@elsikora/cladi";
 export interface GraphContracts {
   graph: IDependencyGraph;
   node: IDependencyGraphNode;
   edge: IDependencyGraphEdge;
 }
-export default GraphContracts`}
+export default GraphContracts`,
+	})}
 />
 
 ### `IInjectableMetadata` and `IModuleDecoratorOptions`
 
 <TSDoc
-	code={`import type { IInjectableMetadata, IModuleDecoratorOptions } from "@elsikora/cladi";
+	definition={generateDefinition({
+		code: `import type { IInjectableMetadata, IModuleDecoratorOptions } from "@elsikora/cladi";
 export interface DecoratorMetadataContracts {
   injectable: IInjectableMetadata;
   module: IModuleDecoratorOptions;
 }
-export default DecoratorMetadataContracts`}
+export default DecoratorMetadataContracts`,
+	})}
 />

--- a/docs/core-concepts/error-handling/page.mdx
+++ b/docs/core-concepts/error-handling/page.mdx
@@ -1,4 +1,4 @@
-import { unstable_TSDoc as TSDoc } from "nextra/tsdoc";
+import { generateDefinition, TSDoc } from "nextra/tsdoc";
 
 # Error Handling
 
@@ -60,6 +60,8 @@ try {
 ## `IBaseErrorOptions`
 
 <TSDoc
-	code={`import type { IBaseErrorOptions } from "@elsikora/cladi";
-export default IBaseErrorOptions`}
+	definition={generateDefinition({
+		code: `import type { IBaseErrorOptions } from "@elsikora/cladi";
+export default IBaseErrorOptions`,
+	})}
 />

--- a/docs/services/logging/page.mdx
+++ b/docs/services/logging/page.mdx
@@ -1,4 +1,4 @@
-import { unstable_TSDoc as TSDoc } from "nextra/tsdoc";
+import { generateDefinition, TSDoc } from "nextra/tsdoc";
 
 # Logging Service
 
@@ -19,8 +19,10 @@ export interface ILogger {
 ### `ILoggerMethodOptions`
 
 <TSDoc
-	code={`import type { ILoggerMethodOptions } from "@elsikora/cladi";
-export default ILoggerMethodOptions`}
+	definition={generateDefinition({
+		code: `import type { ILoggerMethodOptions } from "@elsikora/cladi";
+export default ILoggerMethodOptions`,
+	})}
 />
 
 ## `ConsoleLoggerService`
@@ -30,8 +32,10 @@ export default ILoggerMethodOptions`}
 ### `IConsoleLoggerOptions`
 
 <TSDoc
-	code={`import type { IConsoleLoggerOptions } from "@elsikora/cladi";
-export default IConsoleLoggerOptions`}
+	definition={generateDefinition({
+		code: `import type { IConsoleLoggerOptions } from "@elsikora/cladi";
+export default IConsoleLoggerOptions`,
+	})}
 />
 
 ## `createLogger()`


### PR DESCRIPTION
…n wrapper

Migrate TSDoc usage from direct code prop to definition prop with generateDefinition. This change affects interface documentation pages for container, provider, and logging contracts.